### PR TITLE
Multi lang support + minor changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'org.evlis'
-version = '1.0.1'
+version = '1.0.2'
 
 def targetJavaVersion = 21
 

--- a/src/main/java/org/evlis/lunamatic/GlobalVars.java
+++ b/src/main/java/org/evlis/lunamatic/GlobalVars.java
@@ -11,6 +11,8 @@ public class GlobalVars {
     public static Boolean debug = false;
     // Check for updates?
     public static Boolean checkUpdates = true;
+    //
+    public static String lang = "en_US";
     // enabled moons:
     public static Boolean fullMoonEnabled = true;
     public static Boolean harvestMoonEnabled = true;

--- a/src/main/java/org/evlis/lunamatic/Lunamatic.java
+++ b/src/main/java/org/evlis/lunamatic/Lunamatic.java
@@ -7,19 +7,26 @@ import com.google.gson.JsonParser;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.evlis.lunamatic.commands.LumaCommand;
 import org.evlis.lunamatic.events.*;
 import org.evlis.lunamatic.triggers.Scheduler;
+
+import org.evlis.lunamatic.utilities.TranslationManager;
 
 import java.io.InputStreamReader;
 import java.lang.module.ModuleDescriptor;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-public final class Lunamatic extends JavaPlugin {
+//getComponentLogger dosent output anything! Fixed that with getServer().getConsoleSender().sendMessage
 
+public final class Lunamatic extends JavaPlugin {
     //private final ConsoleCommandSender consoleLogger = getServer().getConsoleSender();
+    private static Lunamatic instance;
+    public TranslationManager translationManager;
+
     public TimeSkip timeSkip;
     public PlayerJoin playerJoin;
     public PlayerQuit playerQuit;
@@ -28,22 +35,60 @@ public final class Lunamatic extends JavaPlugin {
     //public final Logger logger = this.getLogger();
     //public final File configFile = new File(this.getDataFolder(), "config.yml");
     private static final String REQUIRED_VERSION = "1.21";
+    public static final int REQUIRED_LANG_VER = 2;
     private static final String API_URL = "https://api.modrinth.com/v2/project/lunamatic/version";
+
+    public void troubleShootLang() {
+        getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + "---Language Troubleshoot Guide---\n1. If you recently updated Lunamatic, it is recommended to delete plugins/Lunamatic/translations folder. (To allow Lunamatic to use recent translation files)\n2. Check for wrong entered language name in Lunamatic/config.yml\n3. If you were messing with the translations files, you might forget to update the lang_ver value.");
+    }
+
+    public void troubleShootConfig() {
+        getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + "---Config Troubleshoot Guide---\n1. If you recently updated Lunamatic, it is recommended to delete plugins/Lunamatic/config.yml file. (To allow Lunamatic to use recent config version)\n2. You might did some typos in Lunamatic/config.yml");
+    }
 
     @Override
     public void onEnable() {
         // Begin Initialization
         this.getComponentLogger().debug(Component.text("Loading Lunamatic...", NamedTextColor.GOLD));
+
+        // Assing instance variable
+        instance = this;
+
         // Get versions
         String serverVersion = getServer().getMinecraftVersion();
         String currentVersion = this.getPluginMeta().getVersion();
         // Check server version, log error if not supported.
         if (!serverVersion.startsWith(REQUIRED_VERSION)) {
-            this.getComponentLogger().error(Component.text("Unsupported server version: " + serverVersion, NamedTextColor.RED));
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + "Unsupported server version detected! Expected ver: "+REQUIRED_VERSION+", Your version: "+serverVersion);
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + "Expect unexpected behaviours or crashes!, It is recommended to use expected version!");
         }
         // Config Initialization
         saveDefaultConfig();
         loadGlobalConfig();
+
+        // Load translations
+        TranslationManager.initialize(getDataFolder(),GlobalVars.lang);
+        translationManager = TranslationManager.getInstance();
+        translationManager.saveDefaultTranslations();
+        translationManager.loadTranslations();
+
+        if (!translationManager.doesTranslationExist(GlobalVars.lang)) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + GlobalVars.lang + " language does NOT exists! Disabling plugin.");
+            troubleShootLang();
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+
+        if (Integer.parseInt(translationManager.getTranslation("lang_ver")) != REQUIRED_LANG_VER) {
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + "Unsupported language version! Disabling plugin. Expected lang ver: "+REQUIRED_LANG_VER);
+            troubleShootLang();
+            Bukkit.getPluginManager().disablePlugin(this);
+            return;
+        }
+
+        getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.GREEN + translationManager.getTranslation("lang_load_success"));
+
         // Update check
         if (GlobalVars.checkUpdates) {
             checkForUpdates(currentVersion);
@@ -64,13 +109,13 @@ public final class Lunamatic extends JavaPlugin {
 
         schedule.GetOmens(this);
         // Notify of successful plugin start
-        this.getComponentLogger().debug(Component.text("Successfully enabled Lunamatic v" + currentVersion, NamedTextColor.GOLD));
+        getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.GOLD + translationManager.getTranslation("plugin_success_load") + currentVersion);
     }
 
     @Override
     public void onDisable() {
         // Plugin shutdown logic
-        this.getComponentLogger().debug(Component.text("Lunamatic has been disabled.", NamedTextColor.GOLD));
+        this.getLogger().warning("Lunamatic has been disabled.");
     }
 
     public void registerCommands() {
@@ -83,6 +128,7 @@ public final class Lunamatic extends JavaPlugin {
             reloadConfig();
             // plugin vars
             GlobalVars.checkUpdates = getConfig().getBoolean("checkForUpdates");
+            GlobalVars.lang = getConfig().getString("lang");
             // moons enabled
             GlobalVars.disabledWorlds = getConfig().getStringList("disabledWorlds");
             GlobalVars.fullMoonEnabled = getConfig().getBoolean("fullMoonEnabled");
@@ -93,12 +139,14 @@ public final class Lunamatic extends JavaPlugin {
             GlobalVars.harvestMoonDieSides = getConfig().getInt("bloodMoonDieSides");
             GlobalVars.bloodMoonDieSides = getConfig().getInt("harvestMoonDieSides");
         } catch (Exception e) {
-            getLogger().severe("Failed to load configuration: " + e.getMessage());
+            getLogger().severe("Failed to load configuration! Disabling plugin. Error: " + e.getMessage());
+            troubleShootConfig();
+            Bukkit.getPluginManager().disablePlugin(this);
         }
     }
 
     public void checkForUpdates(String currentVersionString) {
-        getLogger().info("Checking for updates...");
+        getLogger().info(translationManager.getTranslation("update_check"));
         try {
             // Open a connection to the API
             HttpURLConnection connection = (HttpURLConnection) new URL(API_URL).openConnection();
@@ -118,13 +166,17 @@ public final class Lunamatic extends JavaPlugin {
             ModuleDescriptor.Version latestVersion = ModuleDescriptor.Version.parse(latestVersionString);
             ModuleDescriptor.Version currentVersion = ModuleDescriptor.Version.parse(currentVersionString);
             if (currentVersion.compareTo(latestVersion) < 0) {
-                this.getComponentLogger().debug(Component.text("New Version " + latestVersionString + " available (you are on v" +  currentVersionString + ")! Download here: https://modrinth.com/plugin/lunamatic", NamedTextColor.GOLD));
+                getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.GOLD + translationManager.getTranslation("update_found").replace("%a",latestVersionString).replace("%b",currentVersionString));
             }
 
             reader.close();
             connection.disconnect();
         } catch (Exception e) {
-            this.getComponentLogger().error(Component.text("Unable to check for updates: " + e.getMessage(), NamedTextColor.RED));
+            getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + translationManager.getTranslation("update_error"));
         }
+    }
+
+    public static Lunamatic getInstance() {
+        return instance;
     }
 }

--- a/src/main/java/org/evlis/lunamatic/commands/LumaCommand.java
+++ b/src/main/java/org/evlis/lunamatic/commands/LumaCommand.java
@@ -88,6 +88,7 @@ public class LumaCommand extends BaseCommand {
         World world = player.getWorld();
         @NotNull MoonPhase moonPhase = world.getMoonPhase();
         // Display GlobalVars status
+        player.sendMessage(getTranslationManager().getTranslation("cmd_lang") + GlobalVars.lang);
         player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_enabled") + GlobalVars.bloodMoonEnabled);
         player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_now") + GlobalVars.bloodMoonNow);
         player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_today") + GlobalVars.bloodMoonToday);

--- a/src/main/java/org/evlis/lunamatic/commands/LumaCommand.java
+++ b/src/main/java/org/evlis/lunamatic/commands/LumaCommand.java
@@ -3,6 +3,9 @@ package org.evlis.lunamatic.commands;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.*;
 import io.papermc.paper.world.MoonPhase;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -10,20 +13,28 @@ import org.bukkit.plugin.Plugin;
 import org.evlis.lunamatic.GlobalVars;
 import org.evlis.lunamatic.utilities.ResetFlags;
 import org.jetbrains.annotations.NotNull;
+import org.evlis.lunamatic.utilities.TranslationManager;
+import org.evlis.lunamatic.Lunamatic;
+import org.evlis.lunamatic.utilities.PlayerMessage;
+
+import static org.evlis.lunamatic.Lunamatic.REQUIRED_LANG_VER;
 
 @CommandAlias("luma")
 public class LumaCommand extends BaseCommand {
-
     private final Plugin plugin; // stores the reference to your main plugin
 
     public LumaCommand(Plugin plugin) {
         this.plugin = plugin;
     }
 
+    private TranslationManager getTranslationManager() {
+        return TranslationManager.getInstance(); // Always fetch the latest instance
+    }
+
     @Default
     public void defCommand(CommandSender sender) {
         // Display GlobalVars status
-        sender.sendMessage("You are running Lunamatic v" + plugin.getPluginMeta().getVersion());
+        sender.sendMessage(getTranslationManager().getTranslation("cmd_running") + plugin.getPluginMeta().getVersion());
     }
 
     @Subcommand("reload")
@@ -33,9 +44,38 @@ public class LumaCommand extends BaseCommand {
         // Display GlobalVars status
         try {
             plugin.reloadConfig();
-            sender.sendMessage("Lunamatic reload successful!");
+            Lunamatic.getInstance().loadGlobalConfig();
+
+            TranslationManager.initialize(plugin.getDataFolder(),GlobalVars.lang);
+
+            getTranslationManager().loadTranslations();
+
+            if (!getTranslationManager().doesTranslationExist(GlobalVars.lang)) {
+                plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + GlobalVars.lang + " language does NOT exists! Disabling plugin.");
+                sender.sendMessage("Error occurred while loading language! Check console.");
+                Lunamatic.getInstance().troubleShootLang();
+                Bukkit.getPluginManager().disablePlugin(plugin);
+                return;
+            }
+
+            if (Integer.parseInt(getTranslationManager().getTranslation("lang_ver")) != REQUIRED_LANG_VER) {
+                plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.RED + "Unsupported language version! Disabling plugin. Expected lang ver: "+REQUIRED_LANG_VER);
+                sender.sendMessage("Error occurred while loading language! Check console.");
+                Lunamatic.getInstance().troubleShootLang();
+                Bukkit.getPluginManager().disablePlugin(plugin);
+                return;
+            }
+
+            plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.GREEN + getTranslationManager().getTranslation("lang_load_success"));
+            sender.sendMessage(getTranslationManager().getTranslation("cmd_reload_success"));
+            if (sender instanceof Player) {
+                PlayerMessage.Send((Player) sender,getTranslationManager().getTranslation("cmd_reload_warn"), NamedTextColor.YELLOW);
+            } else {
+                plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + GlobalVars.lang + getTranslationManager().getTranslation("cmd_reload_warn"));
+            }
+
         } catch (Exception e) {
-            sender.sendMessage("Lunamatic encountered an error: " + e.getMessage());
+            sender.sendMessage(getTranslationManager().getTranslation("cmd_reload_fail") + e.getMessage());
         }
     }
 
@@ -48,14 +88,14 @@ public class LumaCommand extends BaseCommand {
         World world = player.getWorld();
         @NotNull MoonPhase moonPhase = world.getMoonPhase();
         // Display GlobalVars status
-        player.sendMessage("Blood Moon Enabled: " + GlobalVars.bloodMoonEnabled);
-        player.sendMessage("Blood Moon Now: " + GlobalVars.bloodMoonNow);
-        player.sendMessage("Blood Moon Today: " + GlobalVars.bloodMoonToday);
-        player.sendMessage("Harvest Moon Enabled: " + GlobalVars.harvestMoonEnabled);
-        player.sendMessage("Harvest Moon Now: " + GlobalVars.harvestMoonNow);
-        player.sendMessage("Harvest Moon Today: " + GlobalVars.harvestMoonToday);
-        player.sendMessage("Disabled worlds: " + String.join(", ", GlobalVars.disabledWorlds));
-        player.sendMessage("Current moon phase for world " + world.getName() + ": " + moonPhase);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_enabled") + GlobalVars.bloodMoonEnabled);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_now") + GlobalVars.bloodMoonNow);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_blood_moon_today") + GlobalVars.bloodMoonToday);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_harv_moon_enabled") + GlobalVars.harvestMoonEnabled);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_harv_moon_now") + GlobalVars.harvestMoonNow);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_harv_moon_today") + GlobalVars.harvestMoonToday);
+        player.sendMessage(getTranslationManager().getTranslation("cmd_disabled_worlds") + String.join(", ", GlobalVars.disabledWorlds));
+        player.sendMessage(getTranslationManager().getTranslation("cmd_curr_phase") + world.getName() + ": " + moonPhase);
     }
 
     @Subcommand("makebloodmoon")

--- a/src/main/java/org/evlis/lunamatic/events/PlayerJoin.java
+++ b/src/main/java/org/evlis/lunamatic/events/PlayerJoin.java
@@ -13,12 +13,13 @@ import org.evlis.lunamatic.Lunamatic;
 import org.evlis.lunamatic.triggers.NightEffects;
 import org.evlis.lunamatic.utilities.PlayerMessage;
 import org.evlis.lunamatic.utilities.ResetFlags;
+import org.evlis.lunamatic.utilities.TranslationManager;
 import org.jetbrains.annotations.NotNull;
 
 public class PlayerJoin implements Listener {
-
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
+        TranslationManager translationManager = TranslationManager.getInstance();
         Player player = event.getPlayer();
         World world = player.getWorld();
         if (world.getPlayers().isEmpty()) {
@@ -33,18 +34,18 @@ public class PlayerJoin implements Listener {
             // currently cannot be separated without a code rewrite.
             if (moonPhase == MoonPhase.FULL_MOON) {
                 if (GlobalVars.harvestMoonToday) {
-                    PlayerMessage.Send(player, "Harvest moon tonight.", NamedTextColor.GOLD);
+                    PlayerMessage.Send(player, translationManager.getTranslation("harvest_moon_tonight"), NamedTextColor.GOLD);
                 } else {
-                    PlayerMessage.Send(player, "Full moon tonight.", NamedTextColor.YELLOW);
+                    PlayerMessage.Send(player, translationManager.getTranslation("full_moon_tonight"), NamedTextColor.YELLOW);
                 }
                 if (time >= 12610) {
                     NightEffects.ApplyMoonlight(player, MoonPhase.FULL_MOON, (24000 - (int)time));
                 }
             } else if (moonPhase == MoonPhase.NEW_MOON) {
                 if (GlobalVars.bloodMoonToday) {
-                    PlayerMessage.Send(player, "Blood moon tonight.", NamedTextColor.DARK_RED);
+                    PlayerMessage.Send(player, translationManager.getTranslation("blood_moon_tonight"), NamedTextColor.DARK_RED);
                 } else {
-                    PlayerMessage.Send(player, "New moon tonight.", NamedTextColor.DARK_GRAY);
+                    PlayerMessage.Send(player, translationManager.getTranslation("new_moon_tonight"), NamedTextColor.DARK_GRAY);
                 }
                 if (time >= 12610) {
                     NightEffects.ApplyMoonlight(player, MoonPhase.NEW_MOON, (24000 - (int)time));

--- a/src/main/java/org/evlis/lunamatic/events/PlayerSleep.java
+++ b/src/main/java/org/evlis/lunamatic/events/PlayerSleep.java
@@ -12,17 +12,18 @@ import org.evlis.lunamatic.GlobalVars;
 import org.evlis.lunamatic.Lunamatic;
 import org.evlis.lunamatic.utilities.PlayerMessage;
 import org.jetbrains.annotations.NotNull;
+import org.evlis.lunamatic.utilities.TranslationManager;
 
 public class PlayerSleep implements Listener {
-
     @EventHandler
     public void onPlayerSleep(PlayerBedEnterEvent event) {
+        TranslationManager translationManager = TranslationManager.getInstance();
         Player player = event.getPlayer();
         World world = player.getWorld();
         @NotNull MoonPhase moonPhase = world.getMoonPhase();
 
         if (GlobalVars.bloodMoonNow) {
-            PlayerMessage.Send(player, "The blood moon shines! You cannot sleep!", NamedTextColor.RED);
+            PlayerMessage.Send(player, translationManager.getTranslation("blood_moon_sleep"), NamedTextColor.RED);
             event.setCancelled(true);
         }
     }

--- a/src/main/java/org/evlis/lunamatic/triggers/NightEffects.java
+++ b/src/main/java/org/evlis/lunamatic/triggers/NightEffects.java
@@ -6,16 +6,17 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.evlis.lunamatic.utilities.PlayerMessage;
+import org.evlis.lunamatic.utilities.TranslationManager;
 
 public class NightEffects {
-
     public static void ApplyMoonlight(Player player, MoonPhase moonPhase, Integer timeTilDawn) {
+        TranslationManager translationManager = TranslationManager.getInstance();
         if (moonPhase == MoonPhase.FULL_MOON) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.LUCK, timeTilDawn, 0));
-            PlayerMessage.Send(player, "You feel lucky!", NamedTextColor.DARK_GREEN);
+            PlayerMessage.Send(player, translationManager.getTranslation("lucky_feel"), NamedTextColor.DARK_GREEN);
         } else if (moonPhase == MoonPhase.NEW_MOON) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.UNLUCK, timeTilDawn, 0));
-            PlayerMessage.Send(player, "You feel wary...", NamedTextColor.DARK_PURPLE);
+            PlayerMessage.Send(player, translationManager.getTranslation("wary_feel"), NamedTextColor.DARK_PURPLE);
         }
 
     }

--- a/src/main/java/org/evlis/lunamatic/triggers/Scheduler.java
+++ b/src/main/java/org/evlis/lunamatic/triggers/Scheduler.java
@@ -5,6 +5,7 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import org.bukkit.ChatColor;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -12,12 +13,16 @@ import org.evlis.lunamatic.GlobalVars;
 import org.evlis.lunamatic.utilities.PlayerMessage;
 import org.evlis.lunamatic.utilities.ResetFlags;
 import org.evlis.lunamatic.utilities.TotoroDance;
+import org.evlis.lunamatic.utilities.TranslationManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Random;
 
 public class Scheduler {
+    private TranslationManager getTranslationManager() {
+        return TranslationManager.getInstance(); // Always fetch the latest instance
+    }
 
     public void GetOmens(Plugin plugin) {
         GlobalRegionScheduler globalRegionScheduler = plugin.getServer().getGlobalRegionScheduler();
@@ -41,7 +46,7 @@ public class Scheduler {
                 // Check if it's the start of the day (0 ticks, 6am)
                 if (time >= 0 && time < 20) {
                     if (GlobalVars.debug) {
-                        plugin.getComponentLogger().debug(Component.text("Resetting defaults for the day..."));
+                        plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + getTranslationManager().getTranslation("sched_daydef_reset"));
                     }
                     // Reset defaults every dawn
                     ResetFlags.resetAll();
@@ -55,18 +60,18 @@ public class Scheduler {
                         int chance = r.nextInt(GlobalVars.harvestMoonDieSides);
                         if (chance == 0 && GlobalVars.harvestMoonEnabled) {
                             GlobalVars.harvestMoonToday = true;
-                            PlayerMessage.Send(playerList, "Harvest moon tonight.", NamedTextColor.GOLD);
+                            PlayerMessage.Send(playerList, getTranslationManager().getTranslation("harvest_moon_tonight"), NamedTextColor.GOLD);
                         } else {
-                            PlayerMessage.Send(playerList, "Full moon tonight.", NamedTextColor.YELLOW);
+                            PlayerMessage.Send(playerList, getTranslationManager().getTranslation("full_moon_tonight"), NamedTextColor.YELLOW);
                         }
                     } else if (moonPhase == MoonPhase.NEW_MOON && GlobalVars.newMoonEnabled) {
                         // Do a dice roll to check if the players are THAT unlucky..
                         int chance = r.nextInt(GlobalVars.bloodMoonDieSides);
                         if (chance == 0 && GlobalVars.bloodMoonEnabled) {
                             GlobalVars.bloodMoonToday = true;
-                            PlayerMessage.Send(playerList, "Blood moon tonight.", NamedTextColor.DARK_RED);
+                            PlayerMessage.Send(playerList, getTranslationManager().getTranslation("blood_moon_tonight"), NamedTextColor.DARK_RED);
                         } else {
-                            PlayerMessage.Send(playerList, "New moon tonight.", NamedTextColor.DARK_GRAY);
+                            PlayerMessage.Send(playerList, getTranslationManager().getTranslation("new_moon_tonight"), NamedTextColor.DARK_GRAY);
                         }
                     }
                 }
@@ -81,9 +86,9 @@ public class Scheduler {
                         plugin.getServer().getScheduler().runTaskLater(plugin, ResetFlags::resetAll, 24000 - (int)time);
                         totoroDance.setRandomTickSpeed(world, 30);
                         totoroDance.setClearSkies(world, (24000 - (int)time));
-                        PlayerMessage.Send(playerList, "You.. hear grass growing?", NamedTextColor.GOLD);
+                        PlayerMessage.Send(playerList, getTranslationManager().getTranslation("grass_growing"), NamedTextColor.GOLD);
                     } else { // if for some reason both flags are still true, we have an invalid state
-                        plugin.getComponentLogger().debug(Component.text("Invalid harvest moon detected!"));
+                        plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + getTranslationManager().getTranslation("sched_invalid_harv"));
                         GlobalVars.harvestMoonToday = false;
                         GlobalVars.harvestMoonNow = false;
                     }
@@ -99,7 +104,7 @@ public class Scheduler {
                         // Ensure global var reset
                         plugin.getServer().getScheduler().runTaskLater(plugin, ResetFlags::resetAll, 24000 - (int)time);
                     } else { // if for some reason both flags are still true, we have an invalid state
-                        plugin.getComponentLogger().debug(Component.text("Invalid blood moon detected!"));
+                        plugin.getServer().getConsoleSender().sendMessage(ChatColor.WHITE + "[Lunamatic] " + ChatColor.RESET + ChatColor.YELLOW + getTranslationManager().getTranslation("sched_invalid_blood"));
                         GlobalVars.bloodMoonToday = false;
                         GlobalVars.bloodMoonNow = false;
                     }

--- a/src/main/java/org/evlis/lunamatic/utilities/TranslationManager.java
+++ b/src/main/java/org/evlis/lunamatic/utilities/TranslationManager.java
@@ -1,0 +1,111 @@
+package org.evlis.lunamatic.utilities;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class TranslationManager {
+    private static TranslationManager instance;
+
+    private final File translationsFolder;
+    private final Map<String, FileConfiguration> translations = new HashMap<>();
+    private final String defaultLanguage;
+
+    public TranslationManager(File pluginFolder, String defaultLanguage) {
+        this.translationsFolder = new File(pluginFolder, "translations");
+        this.defaultLanguage = defaultLanguage;
+
+        if (!translationsFolder.exists()) {
+            translationsFolder.mkdirs();
+        }
+    }
+
+    public static void initialize(File pluginFolder, String defaultLanguage) {
+        instance = new TranslationManager(pluginFolder, defaultLanguage);
+    }
+
+    public static TranslationManager getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("TranslationManager is not initialized. Call initialize() first.");
+        }
+        return instance;
+    }
+
+    public void loadTranslations() {
+        File[] files = translationsFolder.listFiles((dir, name) -> name.endsWith(".yml"));
+        if (files != null) {
+            for (File file : files) {
+                String language = file.getName().replace(".yml", "");
+                FileConfiguration config = YamlConfiguration.loadConfiguration(file);
+                translations.put(language, config);
+            }
+        }
+    }
+
+    public void saveDefaultTranslations() {
+        try {
+            // Get the plugin JAR file
+            String jarPath = getClass().getProtectionDomain().getCodeSource().getLocation().toURI().getPath();
+            JarFile jarFile = new JarFile(jarPath);
+
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+
+                // Check for files in the /translations/ folder
+                if (entry.getName().startsWith("translations/") && entry.getName().endsWith(".yml")) {
+                    String fileName = entry.getName().replace("translations/", "");
+                    File translationFile = new File(translationsFolder, fileName);
+
+                    if (!translationFile.exists()) {
+                        try (InputStream inputStream = getClass().getResourceAsStream("/" + entry.getName())) {
+                            if (inputStream != null) {
+                                Files.copy(inputStream, translationFile.toPath());
+                            }
+                        }
+                    }
+                }
+            }
+
+            jarFile.close();
+        } catch (IOException | URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public String getTranslation(String key) {
+        FileConfiguration config = translations.getOrDefault(defaultLanguage, translations.get(defaultLanguage));
+        if (config != null) {
+            String translate = config.getString(key);
+            if (translate == null) {
+                System.err.println("Translation missing! Try removing plugins/Lunamatic/translations folder. Key> "+key);
+                return "langErr> "+key;
+            }
+            return translate;
+        } else {
+            System.err.println("Translation file is missing! Key> "+key);
+            return "translaErr>: "+key;
+        }
+
+    }
+
+    public boolean doesTranslationExist(String language) {
+        if (translations.containsKey(language)) {
+            return true;
+        }
+
+        File translationFile = new File(translationsFolder, language + ".yml");
+        return translationFile.exists();
+    }
+}
+

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,10 @@
 ### Lunamatic configuration ###
+
+#Choose plugin language, you can find all of supported translations in plugins/lunamatic/translations
+#You can create your own translations, by copying the English one, renaming and translating the language file.
+#Contribute your translations here: https://github.com/Ifiht/Lunatic
+lang: "en_US"
+
 # Choose which moon effects to enable
 fullMoonEnabled: true
 newMoonEnabled: true
@@ -14,7 +20,6 @@ harvestMoonDieSides: 2
 # Set worlds to disable moon-effects on ###
 # by design both nether & the_end cannot have moon effects
 disabledWorlds:
-  - world
   - world_nether
   - world_the_end
 # Do you want to check for updates at server start?

--- a/src/main/resources/translations/cs_CZ.yml
+++ b/src/main/resources/translations/cs_CZ.yml
@@ -14,6 +14,8 @@ cmd_reload_success: "Znovu načtení Lunamaticu proběhlo úspěšně!"
 cmd_reload_fail: "Při znovu načítání Lunamaticu se vyskytla chyba! Cbyba: "
 cmd_reload_warn: "Po provedení znovu načtení se můžou vyskytnou různé potíže.\nPoužívejte znovu načtení jenom při testování."
 
+cmd_lang: "Načtený jazyk: "
+
 cmd_blood_moon_enabled: "Povolení Krvavého měsíce: "
 cmd_blood_moon_now: "Krvavý měsíc právě probíhá: "
 cmd_blood_moon_today: "Krvavý měsíc dnes: "

--- a/src/main/resources/translations/cs_CZ.yml
+++ b/src/main/resources/translations/cs_CZ.yml
@@ -1,0 +1,45 @@
+# Czech translation, by Thomas Marek (tommarek)
+
+lang_load_success: "Bravo! Jazyk cs_CZ byl načten úspěšně!"
+
+plugin_success_load: "Plugin Lunamatic byl načten úspěsně! Verze: "
+
+update_check: "Hledám aktulizace..."
+update_found: "Nová verze %a je k dispozici! (vaše verze: v%b)! Novou verzi stáhňete zde: https://modrinth.com/plugin/lunamatic"
+update_error: "Chyba při hledání aktulizace: "
+
+cmd_running: "Aktuální verze Lunamatic: "
+
+cmd_reload_success: "Znovu načtení Lunamaticu proběhlo úspěšně!"
+cmd_reload_fail: "Při znovu načítání Lunamaticu se vyskytla chyba! Cbyba: "
+cmd_reload_warn: "Po provedení znovu načtení se můžou vyskytnou různé potíže.\nPoužívejte znovu načtení jenom při testování."
+
+cmd_blood_moon_enabled: "Povolení Krvavého měsíce: "
+cmd_blood_moon_now: "Krvavý měsíc právě probíhá: "
+cmd_blood_moon_today: "Krvavý měsíc dnes: "
+
+cmd_harv_moon_enabled: "Povolení Úrodného měsíce: "
+cmd_harv_moon_now: "Úrodný měsíc právě probíhá: "
+cmd_harv_moon_today: "Úrodný měsíc dnes: "
+
+cmd_disabled_worlds: "Světy ve kterých je Lutematic vyplý: "
+cmd_curr_phase: "Momentální fáze měsíce: "
+
+sched_invalid_blood: "Neplatný krvavý měsíc! Vybírání měsíce bude přeskočeno..."
+sched_invalid_harv: "Neplatný úrodný měsíc! Vybírání měsíce bude přeskočeno..."
+
+sched_daydef_reset: "Resetuji výchozí nastavení pro daný den..."
+
+harvest_moon_tonight: "Dnes očekávejte měsíc Úrody na obloze."
+full_moon_tonight: "Dnes bude viditelný úplněk na obloze."
+blood_moon_tonight: "Dnes očekávejte Krvavý měsíc na obloze"
+new_moon_tonight: "Dnes bude měsíc ve fázi novu."
+
+grass_growing: "Psstt.. Slyšíš tu trávu rúst?"
+lucky_feel: "Cítíš se šťasně!"
+wary_feel: "Být tebou, byl bych více ostražitý..."
+
+blood_moon_sleep: "Jsi hodně rozrušený kvůli Krvavého měsíce. Možná by si měl radši strážit..."
+
+# DO NOT CHANGE THIS VARIABLE! Mismatch of lang_ver can cause some of the translations missing.
+lang_ver: "2"

--- a/src/main/resources/translations/en_US.yml
+++ b/src/main/resources/translations/en_US.yml
@@ -14,6 +14,8 @@ cmd_reload_success: "Lunamatic reload successful!"
 cmd_reload_fail: "Lunamatic encountered an error: "
 cmd_reload_warn: "By reloading the Lunamatic, some issues could occur.\nUse reload only for testing purposes."
 
+cmd_lang: "Loaded Language: "
+
 cmd_blood_moon_enabled: "Blood Moon Enabled: "
 cmd_blood_moon_now: "Blood Moon Now: "
 cmd_blood_moon_today: "Blood Moon Today: "

--- a/src/main/resources/translations/en_US.yml
+++ b/src/main/resources/translations/en_US.yml
@@ -1,0 +1,45 @@
+# Default english translation, Use as template for translating!
+
+lang_load_success: "Bingo! en_US language successfully loaded!"
+
+plugin_success_load: "Successfully enabled Lunamatic v"
+
+update_check: "Checking for updates..."
+update_found: "New version %a available (you are on v%b)! Download here: https://modrinth.com/plugin/lunamatic"
+update_error: "Unable to check for updates: "
+
+cmd_running: "You are running Lunamatic v"
+
+cmd_reload_success: "Lunamatic reload successful!"
+cmd_reload_fail: "Lunamatic encountered an error: "
+cmd_reload_warn: "By reloading the Lunamatic, some issues could occur.\nUse reload only for testing purposes."
+
+cmd_blood_moon_enabled: "Blood Moon Enabled: "
+cmd_blood_moon_now: "Blood Moon Now: "
+cmd_blood_moon_today: "Blood Moon Today: "
+
+cmd_harv_moon_enabled: "Harvest Moon Enabled: "
+cmd_harv_moon_now: "Harvest Moon Now: "
+cmd_harv_moon_today: "Harvest Moon Today: "
+
+cmd_disabled_worlds: "Disabled worlds: "
+cmd_curr_phase: "Current moon phase for world "
+
+sched_invalid_blood: "Invalid blood moon detected! Skipping..."
+sched_invalid_harv: "Invalid harvest moon detected! Skipping..."
+
+sched_daydef_reset: "Resetting defaults for the day..."
+
+harvest_moon_tonight: "Harvest moon tonight."
+full_moon_tonight: "Full moon tonight."
+blood_moon_tonight: "Blood moon tonight."
+new_moon_tonight: "New moon tonight."
+
+grass_growing: "You.. hear grass growing?"
+lucky_feel: "You feel lucky!"
+wary_feel: "You feel wary..."
+
+blood_moon_sleep: "The blood moon shines! You cannot sleep!"
+
+# DO NOT CHANGE THIS VARIABLE! Mismatch of lang_ver can cause some of the translations missing.
+lang_ver: "2"


### PR DESCRIPTION
**I wanna contribute to this plugin, I saw the plugin lacks the multi lang support so I added it with minor buxfixes.**

1. Multi lang support, it does consists from TranslationManager.java wich is basically class that handles the multi lang support. It does get load in Lunamatic.class with language name specified in config.yml under "lang". If the plugin fails to find the translation file it would disable the plugin and gives the server operator some trouble shooting tips. The plugin would get disabled even if the translation version missmatches with the version provided in Lanamatic.class. Then the translation token could be accessed with `translationManager.getTranslation("example")` In order to be synced with the 
Lunamatic lang, on each access for token the translationManager needs to match the current TranslationManager instance.

2. Improved `/luna reload`. It does now reload all variables from config.yml, even the language. It does display warning message when executed, that something can go wrong and it should be used only while testing. Because it does reset the TranslationManager instance, the TranslationManager refferences cannot be final!

3. Fixed that `getComponentLogger` didn't output any text. Instead that I used `getServer().getConsoleSender().sendMessagee()`. It does use ChatColor witch is deprecated. I will take look on it in future. But for now it does work.

4. Allowed so users can use it on another version of Paper, but they are encouraged to do NOT do that, and it could behave unexpectedly or even crash. (Because some plugins work on newer versions)

5. Removed `world` from `disabledWorlds` in default config.yml. It is little bit confusing that main world isn't enabled by default.

**How to add more languages?**
- Only translated .yml file needs to be placed into the src/main/resources/translations
- I introduced only two langs files for start (Czech and English)
- While translating, the lang_ver needs to be set accordingly to the lang_ver that is defined i Lunamatic.class

- [x] Everything on loading of the server was tested
- [x] Translations were tested
- [x] /luna reload was tested
- [x] 20 mins test was performed and there wasn't any issue present.
- [x] 24h test (I would try it today, while pushing it on my server for my friends)
